### PR TITLE
fix:  pin verida-packages version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "react-stater-kit",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@verida/account-web-vault": "^1.1.12",
-    "@verida/client-ts": "^1.1.15",
-    "https-browserify": "^1.0.0",
-    "process": "^0.11.10",
-    "react": "^18.2.0",
-    "react-app-rewired": "^2.2.1",
-    "react-copy-to-clipboard": "^5.1.0",
-    "react-dom": "^18.2.0",
-    "react-loader-spinner": "^5.3.4",
-    "react-router-dom": "6",
-    "react-scripts": "5.0.1",
-    "react-toastify": "^7.0.4",
-    "stream-http": "^3.2.0",
-    "url": "^0.11.0",
-    "util": "^0.12.4",
-    "web-vitals": "^2.1.4"
-  },
-  "scripts": {
-    "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
-    "test": "react-app-rewired test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+	"name": "react-stater-kit",
+	"version": "0.1.0",
+	"private": true,
+	"dependencies": {
+		"@testing-library/jest-dom": "^5.16.5",
+		"@testing-library/react": "^13.4.0",
+		"@testing-library/user-event": "^13.5.0",
+		"@verida/account-web-vault": "~1.1.12",
+		"@verida/client-ts": "~1.1.15",
+		"https-browserify": "^1.0.0",
+		"process": "^0.11.10",
+		"react": "^18.2.0",
+		"react-app-rewired": "^2.2.1",
+		"react-copy-to-clipboard": "^5.1.0",
+		"react-dom": "^18.2.0",
+		"react-loader-spinner": "^5.3.4",
+		"react-router-dom": "6",
+		"react-scripts": "5.0.1",
+		"react-toastify": "^7.0.4",
+		"stream-http": "^3.2.0",
+		"url": "^0.11.0",
+		"util": "^0.12.4",
+		"web-vitals": "^2.1.4"
+	},
+	"scripts": {
+		"start": "react-app-rewired start",
+		"build": "react-app-rewired build",
+		"test": "react-app-rewired test",
+		"eject": "react-scripts eject"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	}
 }


### PR DESCRIPTION
- Pinned verida-packages version to `1.x.x`  , due the public version of verida-ts 2.0 being on  NPM we should pin the version in our demos to 1.x 